### PR TITLE
Added ability to poll for container stats instead of constant stream

### DIFF
--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -85,6 +85,14 @@ type Config struct {
 	// sent to the ECS telemetry endpoint
 	DisableMetrics bool
 
+	// StreamMetrics configures whether metrics are constantly streamed for each container or
+	// polled on interval instead.
+	StreamMetrics bool
+
+	// PollingMetricsWaitDuration configures how long a container should wait before polling metrics
+	// again when StreamMetrics is set to false
+	PollingMetricsWaitDuration time.Duration
+
 	// ReservedMemory specifies the amount of memory (in MB) to reserve for things
 	// other than containers managed by ECS
 	ReservedMemory uint16

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"strings"
 	"sync"
 	"time"
@@ -986,24 +987,57 @@ func (dg *dockerGoClient) Stats(id string, ctx context.Context) (<-chan *docker.
 		return nil, err
 	}
 
-	stats := make(chan *docker.Stats)
-	options := docker.StatsOptions{
-		ID:                id,
-		Stats:             stats,
-		Stream:            true,
-		Context:           ctx,
-		InactivityTimeout: StatsInactivityTimeout,
+	returnStats := make(chan *docker.Stats)
+
+	if dg.config.StreamMetrics {
+		options := docker.StatsOptions{
+			ID:                id,
+			Stats:             returnStats,
+			Stream:            true,
+			Context:           ctx,
+			InactivityTimeout: StatsInactivityTimeout,
+		}
+	
+		go func() {
+			statsErr := client.Stats(options)
+			if statsErr != nil {
+				seelog.Infof("DockerGoClient: Unable to retrieve stats for container %s: %v",
+					id, statsErr)
+			}
+		}()
+	} else {
+
+		//Sleep for a random period time up to the polling interval. This will help make containers ask for stats at different times
+		time.Sleep(time.Second * time.Duration(rand.Intn(int(dg.config.PollingMetricsWaitDuration.Seconds()))))
+
+		go func() {
+			for {
+
+				stats := make(chan *docker.Stats, 1)
+				options := docker.StatsOptions{
+					ID:                id,
+					Stats:             stats,
+					Stream:            false,
+					Context:           ctx,
+					InactivityTimeout: StatsInactivityTimeout,
+				}
+				statsErr := client.Stats(options)
+				if statsErr != nil {
+					seelog.Infof("DockerGoClient: Unable to retrieve stats for container %s: %v", id, statsErr)
+				}
+
+				dockerStats, ok := <-stats
+				if ok {
+					seelog.Infof("DockerGoClient: Retrieved stats for container %s:", id)
+					returnStats <- dockerStats
+				}
+
+				time.Sleep(dg.config.PollingMetricsWaitDuration)
+			}
+		}()
 	}
 
-	go func() {
-		statsErr := client.Stats(options)
-		if statsErr != nil {
-			seelog.Infof("DockerGoClient: Unable to retrieve stats for container %s: %v",
-				id, statsErr)
-		}
-	}()
-
-	return stats, nil
+	return returnStats, nil
 }
 
 // RemoveImage invokes github.com/fsouza/go-dockerclient.Client's


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Allows for container stat polling instead of forcing constant stream. This allows for a significant decrease in CPU usage when a lot of containers are deployed.

### Implementation details
There's 2 environment configuration variables that allow you to disable stream (default is to leave streaming turned on) and specify the polling interval (default is 15 seconds).

### Testing
This was tested by replacing the ecs-agent container on a ECS host with over 150 containers.

- [x] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
Feature - Allow for Container Stat Polling

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
